### PR TITLE
feat: upgrade to version 3.0.0 and add new providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.0.0] - 2026-08-10
+
+### Changed
+
+#### BREAKING: string literals are now unescaped
+
+`\'`, `\"` and `\\` inside a string literal are now resolved. Previously the raw text between the quotes was used verbatim, so the backslash stayed in the value.
+
+| Expression  | 2.x       | 3.0.0    |
+| ----------- | --------- | -------- |
+| `'it\'s'`   | `it\'s`   | `it's`   |
+| `"a\"b"`    | `a\"b`    | `a"b`    |
+| `'c:\\tmp'` | `c:\\tmp` | `c:\tmp` |
+
+**Nothing else changes.** Only string literals containing a backslash behave differently. Arithmetic, comparison, logic, bitwise operators, concatenation, collections, ranges, attribute access, functions and error messages are all unchanged, for both `evaluate()` and `compile()`.
+
+**Your regex patterns are safe.** Unrecognized escapes are passed through untouched, so `'\d'`, `'\w'` and `'\n'` reach `matches` exactly as before and every existing pattern such as `'/^\d{4}-\d{2}$/'` keeps working.
+
+**Migration.** Only doubled backslashes change meaning. If you doubled them to work around the old behavior, remove the doubling:
+
+```diff
+- '2026-07' matches '/^\\d{4}/'   // was a literal backslash, never matched
++ '2026-07' matches '/^\d{4}/'    // digit class
+```
+
+To match a literal backslash, write `'/\\\\d/'`.
+
+#### `Parser.parse()` and `Parser.lint()` validate the `names` argument
+
+Passing a non-array `names` now throws `TypeError: The "names" argument must be an array.`
+
+For almost everyone this is a better message rather than a change in behavior. `null` and `undefined` already threw `TypeError: Cannot read properties of undefined (reading 'length')`, so the error class is unchanged and existing `catch` blocks behave the same. Going through `ExpressionLanguage` — `evaluate()`, `compile()`, `parse()`, `lint()` — nothing changes at all.
+
+The one real break is calling the exported `Parser` class directly with a bare string: `parser.parse(stream, 'a')` was treated as `['a']` and now throws. Pass an array.
+
+### Added
+
+- **Opt-in function providers** behind a new `/providers` entry point, shipped as ESM, CJS, UMD and typings. They are not part of the core bundle, and — like the rest of the package — carry no runtime dependencies.
+
+  ```ts
+  import { ExpressionLanguage } from '@andreasnicolaou/typescript-expression-language';
+  import { StringProvider } from '@andreasnicolaou/typescript-expression-language/providers';
+
+  const el = new ExpressionLanguage(undefined, [new StringProvider()]);
+  el.evaluate('strtoupper(substr(name, 0, 3))', { name: 'andreas' }); // "AND"
+  ```
+
+  | Provider         | Functions                                                                                                                                                   |
+  | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | `MathProvider`   | `abs`, `ceil`, `floor`, `round`, `sqrt`, `pow`                                                                                                              |
+  | `StringProvider` | `strtolower`, `strtoupper`, `strlen`, `trim`, `ltrim`, `rtrim`, `ucfirst`, `lcfirst`, `ucwords`, `strrev`, `explode`, `str_replace`, `substr`               |
+  | `ArrayProvider`  | `count`, `implode`, `array_keys`, `array_values`, `array_merge`, `array_reverse`, `array_unique`, `array_sum`, `in_array`, `array_intersect`, `array_slice` |
+  | `DateProvider`   | `checkdate`, `date`, `date_parse`, `gmdate`, `gmmktime`, `mktime`, `strtotime`, `time`                                                                      |
+
+  `MathProvider` omits `min`/`max`, which are registered by default. `DateProvider` uses PHP **second** timestamps.
+
+- A **By example** section in the README listing every supported literal, operator, conditional, collection and function form alongside the value it evaluates to.
+
+## [2.0.0] - 2026-07-21
+
+Releases up to and including 2.0.0 are documented in the [GitHub releases](https://github.com/andreasnicolaou/typescript-expression-language/releases).
+
+[3.0.0]: https://github.com/andreasnicolaou/typescript-expression-language/compare/v2.0.0...v3.0.0
+[2.0.0]: https://github.com/andreasnicolaou/typescript-expression-language/releases/tag/v2.0.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A **TypeScript-native** implementation of the **Symfony Expression Language** — written in TypeScript from the ground up, not transpiled JavaScript with bolted-on type definitions.
 
-Evaluate complex expressions client-side with full Symfony parity, a bounded LRU cache, ESM/CJS/UMD output, and zero peer dependencies.
+Evaluate complex expressions client-side with Symfony-faithful semantics, a bounded LRU cache, ESM/CJS/UMD output, and zero peer dependencies.
 
 ![TypeScript](https://img.shields.io/badge/TS-TypeScript-3178c6?logo=typescript&logoColor=white)
 ![GitHub contributors](https://img.shields.io/github/contributors/andreasnicolaou/typescript-expression-language)
@@ -20,6 +20,8 @@ Evaluate complex expressions client-side with full Symfony parity, a bounded LRU
 [![Socket Badge](https://badge.socket.dev/npm/package/@andreasnicolaou/typescript-expression-language)](https://badge.socket.dev/npm/package/@andreasnicolaou/typescript-expression-language)
 
 ![NPM Downloads](https://img.shields.io/npm/dm/%40andreasnicolaou%2Ftypescript-expression-language)
+
+📋 **[Changelog](https://github.com/andreasnicolaou/typescript-expression-language/blob/main/CHANGELOG.md)** — read this before upgrading across a major version.
 
 <details>
   <summary>📊 Code Coverage Visualizations</summary>
@@ -60,7 +62,7 @@ You can try this library live:
 - **TypeScript-native source**: Types are generated from the implementation — never out of sync with the API.
 - **ESM-first**: Tree-shakeable ES module output alongside CJS and UMD. Use only what you import.
 - **Bounded LRU cache**: Parsed expressions are cached in a lightweight 500-entry `ArrayCache`, which can be replaced with a custom cache.
-- **Full Symfony parity**: Every operator, literal type, and access pattern from Symfony's ExpressionLanguage works identically here.
+- **Symfony-faithful semantics**: Operators, precedence, literals, and error behavior follow Symfony's ExpressionLanguage — `1 / 0` throws `Division by zero.` rather than returning `Infinity`. Values are JavaScript-native, and PHP stdlib functions are opt-in via `/providers`.
 - **Zero peer dependencies**: No packages to install alongside this one — everything is self-contained.
 - **Rich syntax**: Numbers (with underscore separators), strings, arrays, hashes, block comments, regex matching, ranges, null-safe operators, and more.
 - **Extensible**: Register custom functions or group them into reusable providers.
@@ -290,6 +292,58 @@ const expressionLanguage = new ExpressionLanguage(customCache);
 > const expressionLanguage = new ExpressionLanguage(cache);
 > ```
 
+### Built-in Providers (opt-in)
+
+Four ready-made providers ship behind the `/providers` entry point. They are not bundled into the core and use the project's existing [Locutus](https://locutus.io/) dependency for PHP-compatible behavior.
+
+| Provider         | Functions                                                                                                                                                   |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MathProvider`   | `abs`, `ceil`, `floor`, `round`, `sqrt`, `pow`                                                                                                              |
+| `StringProvider` | `strtolower`, `strtoupper`, `strlen`, `trim`, `ltrim`, `rtrim`, `ucfirst`, `lcfirst`, `ucwords`, `strrev`, `explode`, `str_replace`, `substr`               |
+| `ArrayProvider`  | `count`, `implode`, `array_keys`, `array_values`, `array_merge`, `array_reverse`, `array_unique`, `array_sum`, `in_array`, `array_intersect`, `array_slice` |
+| `DateProvider`   | `checkdate`, `date`, `date_parse`, `gmdate`, `gmmktime`, `mktime`, `strtotime`, `time`                                                                      |
+
+```typescript
+import { ExpressionLanguage } from '@andreasnicolaou/typescript-expression-language';
+import {
+  StringProvider,
+  ArrayProvider,
+  MathProvider,
+  DateProvider,
+} from '@andreasnicolaou/typescript-expression-language/providers';
+
+const el = new ExpressionLanguage(undefined, [
+  new StringProvider(),
+  new ArrayProvider(),
+  new MathProvider(),
+  new DateProvider(),
+]);
+
+console.log(el.evaluate('strtoupper(substr(name, 0, 3))', { name: 'andreas' })); // "AND"
+console.log(el.evaluate('implode(", ", array_unique([1, 1, 2, 3]))')); // "1, 2, 3"
+console.log(el.evaluate('round(pow(2, 0.5), 4)')); // 1.4142
+console.log(el.evaluate('gmdate("Y", 0)')); // "1970"
+```
+
+> **Note:** `MathProvider` intentionally omits `min`/`max` — those are already registered by default. `DateProvider` uses PHP **second** timestamps: `strtotime()` returns seconds and `date()` accepts seconds. Provider expressions compile to named calls such as `strtoupper(name)`; provide the matching Locutus function when executing compiled output outside this library.
+
+#### Browser (UMD via CDN)
+
+The providers also ship as a UMD bundle. Load the core and providers scripts, then read the providers off the `typescriptExpressionLanguageProviders` global:
+
+```html
+<!-- Use .umd.js for debugging, .umd.min.js for production -->
+<script src="https://unpkg.com/@andreasnicolaou/typescript-expression-language/dist/index.umd.min.js"></script>
+<script src="https://unpkg.com/@andreasnicolaou/typescript-expression-language/dist/providers.umd.min.js"></script>
+<script>
+  const { ExpressionLanguage } = typescriptExpressionLanguage;
+  const { StringProvider, ArrayProvider } = typescriptExpressionLanguageProviders;
+
+  const el = new ExpressionLanguage(undefined, [new StringProvider(), new ArrayProvider()]);
+  console.log(el.evaluate('strtoupper("hi") ~ "-" ~ count([1, 2, 3])')); // "HI-3"
+</script>
+```
+
 ### Custom Providers
 
 #### Add a Simple Math Provider
@@ -332,8 +386,6 @@ class UtilsProvider implements ExpressionFunctionProvider {
       ExpressionFunction.fromJs('isEven', (x: number) => x % 2 === 0),
       ExpressionFunction.fromJs('maxInArray', (arr: number[]) => Math.max(...arr)),
       ExpressionFunction.fromJs('join', (arr: string[], sep: string) => arr.join(sep)),
-      ExpressionFunction.fromJs('strtolower', (str: string) => (str + '').toLowerCase()), // PHP strtolower
-      ExpressionFunction.fromJs('strtoupper', (str: string) => (str + '').toUpperCase()), // PHP strtoupper
     ];
   }
 }
@@ -343,13 +395,85 @@ const el = new ExpressionLanguage(undefined, [new UtilsProvider()]);
 console.log(el.evaluate('isEven(10)')); // Outputs → true
 console.log(el.evaluate('maxInArray([1, 5, 3, 9])')); // Outputs → 9
 console.log(el.evaluate('join(["a", "b", "c"], ",")')); // Outputs → "a,b,c"
-console.log(el.evaluate('strtolower("HELLO")')); // Outputs → "hello"
-console.log(el.evaluate('strtoupper("world")')); // Outputs → "WORLD"
 ```
+
+> For common PHP-style helpers like `strtolower`/`strtoupper`/`substr`, use the [built-in providers](#built-in-providers-opt-in). Write a custom provider (as above) only for logic specific to your app. Both the built-in providers and `ExpressionFunction.fromJs('name', fn)` compile to bare `name(...)` calls, so the function must exist in scope when executing compiled output.
 
 ---
 
 ## 📋 Supported Syntax
+
+### By example
+
+Every line below is a real expression and the value it evaluates to (`// →`). Variables used are noted in parentheses.
+
+**Literals** — single/double quotes, underscore separators, no-leading-zero and scientific numbers, arrays, hashes, block comments
+
+<!-- prettier-ignore -->
+```js
+1_000_000                       // → 1000000
+.5 + 1.5e2                      // → 150.5
+'single' ~ " & double"          // → 'single & double'
+[1, 2, 3]                       // → [1, 2, 3]
+{"a": 1, "b": 2}                // → { a: 1, b: 2 }
+/* inline */ 6 * 7              // → 42
+```
+
+**Arithmetic, comparison & logic** — including word operators (`and`, `not`, `xor`)
+
+<!-- prettier-ignore -->
+```js
+2 ** 3 % 5                      // → 3
+(1 + 2) * 3 - 10 / 4            // → 6.5
+1 === 1 and 1 !== '1'           // → true
+true and not false              // → true
+true xor false                  // → true
+```
+
+**Strings & pattern matching**
+
+<!-- prettier-ignore -->
+```js
+'Hello, ' ~ name ~ '!'          // → 'Hello, World!'   (name = 'World')
+'it\'s a test'                  // → 'it's a test'     (escaped quote)
+'foobar' starts with 'foo'      // → true
+'foobar' contains 'oba'         // → true
+'2026-07' matches '/^\d{4}-\d{2}$/'   // → true
+```
+
+**Conditionals** — ternary, elvis (`?:`), null-coalesce (`??`), null-safe (`?.`)
+
+<!-- prettier-ignore -->
+```js
+age >= 18 ? 'adult' : 'minor'   // → 'adult'   (age = 30)
+nickname ?: 'anon'              // → 'anon'    (nickname = '')
+user.middle ?? 'n/a'            // → 'n/a'     (user.middle = null)
+user?.profile?.city             // → null      (user.profile = null)
+```
+
+**Collections, ranges & access**
+
+<!-- prettier-ignore -->
+```js
+matrix[1][0]                    // → 3         (matrix = [[1, 2], [3, 4]])
+obj.greet(user)                 // → 'hi sam'  (obj.greet = u => 'hi ' + u, user = 'sam')
+3 in [1, 2, 3]                  // → true
+'z' not in ['a', 'b']           // → true
+1..5                            // → [1, 2, 3, 4, 5]
+```
+
+**Bitwise & functions**
+
+<!-- prettier-ignore -->
+```js
+5 & 3                           // → 1
+~5                              // → -6
+1 << 4                          // → 16
+max(min(9, 4), 2)               // → 4
+constant('Math.PI')             // → 3.141592653589793
+enum('Status.ACTIVE').code      // → 1
+isset(user.email)               // → true      (user.email = 'a@b.c')
+```
 
 ### Operators
 
@@ -382,6 +506,8 @@ Add and register custom functions for flexible application logic.
 ## 🛠️ Available Functions
 
 The library provides access to a comprehensive set of JavaScript functions. Some are **enabled by default**, while others can be registered using `ExpressionFunction.fromJs()`.
+
+> This table is the **JavaScript-native** set you register one at a time with `ExpressionFunction.fromJs()` (e.g. `toLowerCase`, `split`, `trim`). If you want **PHP-named** helpers instead (`strtolower`, `substr`, `count`, `implode`, `date`…), grab them from the opt-in [built-in providers](#built-in-providers-opt-in), backed by Locutus.
 
 | Function             | Category | Enabled by Default | Description                                              | Example                                             |
 | -------------------- | -------- | :----------------: | -------------------------------------------------------- | --------------------------------------------------- |
@@ -534,11 +660,13 @@ These use cases demonstrate how the library can bring advanced, real-time logic 
 
 ## 🛡️ Symfony Compatibility
 
-This library ensures that expressions written in PHP's **Symfony Expression Language** are fully compatible with the client-side implementation. This enables seamless integration between server-side logic (written in Symfony/PHP) and client-side expression evaluation.
+This library follows Symfony's ExpressionLanguage semantics rather than JavaScript's where the two disagree. Operators, precedence, literals, and error behavior match Symfony: `1 / 0` and `10 % 0` throw instead of returning `Infinity`/`NaN`, `enum()` throws on an unknown case instead of returning `undefined`, and string literals unescape like PHP's — `'\\'` is one backslash while `'\d'` stays `\d`, so regex patterns survive.
+
+**What differs by design:** values stay JavaScript-native. Numbers are IEEE-754 doubles, not PHP ints. `~` concatenates using **JavaScript** coercion, so `"v=" ~ null` is `"v=null"` and `"v=" ~ true` is `"v=true"` where PHP would give `"v="` and `"v=1"`. `matches` uses JavaScript regular expressions rather than PCRE. And the PHP standard library is not registered by default — those functions are opt-in via the [built-in providers](#built-in-providers-opt-in).
 
 ### **Key Benefits:**
 
-- **Consistency**: Expressions behave the same way on both the client and the server.
+- **Predictable across the stack**: Expressions that rely on Symfony's operator and error semantics evaluate the same way here.
 - **Synchronization**: Ensure business logic is applied consistently across both sides of the application without discrepancies.
 - **Easy Integration**: Easily synchronize the logic between your PHP backend and TypeScript frontend, without needing separate implementations.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@andreasnicolaou/typescript-expression-language",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@andreasnicolaou/typescript-expression-language",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@codecov/rollup-plugin": "^2.0.1",
@@ -18,23 +18,23 @@
         "@rollup/plugin-typescript": "^12.3.0",
         "@types/jest": "^30.0.0",
         "@types/locutus": "^0.0.8",
-        "@types/node": "^26.1.1",
-        "@typescript-eslint/eslint-plugin": "^8.64.0",
-        "@typescript-eslint/parser": "^8.64.0",
+        "@types/node": "^26.2.0",
+        "@typescript-eslint/eslint-plugin": "^8.66.0",
+        "@typescript-eslint/parser": "^8.66.0",
         "cross-env": "^10.1.0",
-        "eslint": "^10.7.0",
+        "eslint": "^10.8.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
-        "globals": "^17.7.0",
+        "globals": "^17.9.0",
         "husky": "^9.1.7",
         "jest": "^30.4.2",
         "jest-junit": "^17.0.0",
         "locutus": "^3.0.36",
-        "prettier": "3.9.4",
+        "prettier": "3.9.6",
         "prettier-plugin-organize-imports": "^4.3.0",
-        "rollup": "^4.62.2",
-        "rollup-plugin-dts": "^6.4.1",
-        "ts-jest": "^29.4.11",
+        "rollup": "^4.62.4",
+        "rollup-plugin-dts": "^6.5.1",
+        "ts-jest": "^29.4.12",
         "ts-node": "^10.9.2",
         "tslib": "^2.8.1",
         "typescript": "^5.9.3"
@@ -712,10 +712,11 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.2.1"
       },
@@ -1552,6 +1553,26 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -1854,325 +1875,389 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
-      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
-      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
-      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
-      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
-      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
-      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
-      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
-      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
-      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
-      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
-      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
-      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
-      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
-      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
-      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
-      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
-      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
-      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
-      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
-      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
-      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
-      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
-      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2328,10 +2413,11 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -2360,16 +2446,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
-      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/type-utils": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/type-utils": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2382,98 +2469,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.64.0",
+        "@typescript-eslint/parser": "^8.66.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
-      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/project-service": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
-      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.64.0",
-        "@typescript-eslint/types": "^8.64.0",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
-      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
-      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
-      "dev": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
-      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2489,29 +2499,17 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/types": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
-      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
       "dev": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
-      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.64.0",
-        "@typescript-eslint/tsconfig-utils": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/project-service": "8.66.0",
+        "@typescript-eslint/tsconfig-utils": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2529,16 +2527,56 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
-      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0"
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2552,13 +2590,205 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
-      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/project-service": "8.66.0",
+        "@typescript-eslint/tsconfig-utils": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.66.0",
+        "@typescript-eslint/tsconfig-utils": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2574,6 +2804,7 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
@@ -3506,15 +3737,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -3538,7 +3773,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -4034,10 +4269,11 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -5572,9 +5808,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5740,10 +5976,11 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
-      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -5755,39 +5992,41 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.62.2",
-        "@rollup/rollup-android-arm64": "4.62.2",
-        "@rollup/rollup-darwin-arm64": "4.62.2",
-        "@rollup/rollup-darwin-x64": "4.62.2",
-        "@rollup/rollup-freebsd-arm64": "4.62.2",
-        "@rollup/rollup-freebsd-x64": "4.62.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
-        "@rollup/rollup-linux-arm64-musl": "4.62.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
-        "@rollup/rollup-linux-loong64-musl": "4.62.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-musl": "4.62.2",
-        "@rollup/rollup-openbsd-x64": "4.62.2",
-        "@rollup/rollup-openharmony-arm64": "4.62.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
-        "@rollup/rollup-win32-x64-gnu": "4.62.2",
-        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
         "fsevents": "~2.3.2"
       }
     },
     "node_modules/rollup-plugin-dts": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.4.1.tgz",
-      "integrity": "sha512-l//F3Zf7ID5GoOfLfD8kroBjQKEKpy1qfhtAdnpibFZMffPaylrg1CoDC2vGkPeTeyxUe4bVFCln2EFuL7IGGg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.5.1.tgz",
+      "integrity": "sha512-jODTXp3H7MK/Ur/ErtsrQ0G1GvaCmc3du+y5pNrdBMf6d7HlL2Nd/N6TkEr+f75CkUj01zEoEd7y2elH0eHi1Q==",
       "dev": true,
+      "license": "LGPL-3.0-only",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
         "@jridgewell/sourcemap-codec": "^1.5.5",
@@ -5801,18 +6040,59 @@
         "url": "https://github.com/sponsors/Swatinem"
       },
       "optionalDependencies": {
-        "@babel/code-frame": "^7.29.0"
+        "@babel/code-frame": "^8.0.0"
       },
       "peerDependencies": {
-        "rollup": "^3.29.4 || ^4",
-        "typescript": "^4.5 || ^5.0 || ^6.0"
+        "@typescript/typescript6": "^6",
+        "rollup": "^3 || ^4",
+        "typescript": "^4.5 || ^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "@typescript/typescript6": {
+          "optional": true
+        }
       }
     },
-    "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+    "node_modules/rollup-plugin-dts/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/rollup-plugin-dts/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/rollup-plugin-dts/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6114,6 +6394,7 @@
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.4"
@@ -6135,6 +6416,7 @@
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.12"
       },
@@ -6143,9 +6425,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.11",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
-      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+      "version": "29.4.12",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
+      "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6155,7 +6437,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.8.0",
+        "semver": "^7.8.5",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -6297,6 +6579,8 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andreasnicolaou/typescript-expression-language",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "TypeScript implementation of symfony/expression-language",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
@@ -13,6 +13,18 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
+    },
+    "./providers": {
+      "import": "./dist/providers.js",
+      "require": "./dist/providers.cjs",
+      "types": "./dist/providers.d.ts"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "providers": [
+        "dist/providers.d.ts"
+      ]
     }
   },
   "files": [
@@ -68,6 +80,26 @@
       "path": "dist/index.umd.min.js",
       "limit": "15kB",
       "gzip": true
+    },
+    {
+      "path": "dist/providers.js",
+      "limit": "30kB",
+      "gzip": true
+    },
+    {
+      "path": "dist/providers.cjs",
+      "limit": "30kB",
+      "gzip": true
+    },
+    {
+      "path": "dist/providers.umd.js",
+      "limit": "30kB",
+      "gzip": true
+    },
+    {
+      "path": "dist/providers.umd.min.js",
+      "limit": "15kB",
+      "gzip": true
     }
   ],
   "jest": {
@@ -92,23 +124,23 @@
     "@rollup/plugin-typescript": "^12.3.0",
     "@types/jest": "^30.0.0",
     "@types/locutus": "^0.0.8",
-    "@types/node": "^26.1.1",
-    "@typescript-eslint/eslint-plugin": "^8.64.0",
-    "@typescript-eslint/parser": "^8.64.0",
+    "@types/node": "^26.2.0",
+    "@typescript-eslint/eslint-plugin": "^8.66.0",
+    "@typescript-eslint/parser": "^8.66.0",
     "cross-env": "^10.1.0",
-    "eslint": "^10.7.0",
+    "eslint": "^10.8.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
-    "globals": "^17.7.0",
+    "globals": "^17.9.0",
     "husky": "^9.1.7",
     "jest": "^30.4.2",
     "jest-junit": "^17.0.0",
     "locutus": "^3.0.36",
-    "prettier": "3.9.4",
+    "prettier": "3.9.6",
     "prettier-plugin-organize-imports": "^4.3.0",
-    "rollup": "^4.62.2",
-    "rollup-plugin-dts": "^6.4.1",
-    "ts-jest": "^29.4.11",
+    "rollup": "^4.62.4",
+    "rollup-plugin-dts": "^6.5.1",
+    "ts-jest": "^29.4.12",
     "ts-node": "^10.9.2",
     "tslib": "^2.8.1",
     "typescript": "^5.9.3"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,23 @@ import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import dts from 'rollup-plugin-dts';
 
+/**
+ * Keeps the core types out of `dist/providers.d.ts` by rewriting the relative
+ * imports the provider sources use into an external import from `./index`.
+ * @type {import('rollup').Plugin}
+ */
+const importCoreTypesFromMainEntry = {
+  name: 'import-core-types-from-main-entry',
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- rollup hook, and a .js config cannot carry a TS annotation
+  resolveId(source) {
+    // The `.js` extension is required by `moduleResolution: node16`/`nodenext`;
+    // TypeScript maps it back to `index.d.ts` under every resolution mode.
+    return source === '../expression-function' || source === '../expression-language'
+      ? { id: './index.js', external: true }
+      : null;
+  },
+};
+
 export default [
   // ESM build
   {
@@ -101,6 +118,94 @@ export default [
       terser(),
     ],
   },
+  // Providers entry point (opt-in) - ESM
+  {
+    input: 'src/providers/index.ts',
+    external: ['node:diagnostics_channel'],
+    output: {
+      file: 'dist/providers.js',
+      format: 'es',
+      sourcemap: false,
+    },
+    plugins: [
+      resolve({ preferBuiltins: false }),
+      commonjs(),
+      typescript({
+        tsconfig: './tsconfig.json',
+        declaration: false,
+        declarationMap: false,
+        tslib: 'bundled',
+      }),
+    ],
+  },
+  // Providers entry point (opt-in) - CommonJS
+  {
+    input: 'src/providers/index.ts',
+    external: ['node:diagnostics_channel'],
+    output: {
+      file: 'dist/providers.cjs',
+      format: 'cjs',
+      sourcemap: false,
+      exports: 'named',
+    },
+    plugins: [
+      resolve({ preferBuiltins: false }),
+      commonjs(),
+      typescript({
+        tsconfig: './tsconfig.json',
+        declaration: false,
+        declarationMap: false,
+        tslib: 'bundled',
+      }),
+    ],
+  },
+  // Providers entry point (opt-in) - UMD (for browser) - unminified
+  {
+    input: 'src/providers/index.ts',
+    output: {
+      file: 'dist/providers.umd.js',
+      format: 'umd',
+      name: 'typescriptExpressionLanguageProviders',
+      sourcemap: false,
+    },
+    plugins: [
+      resolve({
+        preferBuiltins: false,
+        browser: true,
+      }),
+      commonjs(),
+      typescript({
+        tsconfig: './tsconfig.json',
+        declaration: false,
+        declarationMap: false,
+        tslib: 'bundled',
+      }),
+    ],
+  },
+  // Providers entry point (opt-in) - UMD (for browser) - minified
+  {
+    input: 'src/providers/index.ts',
+    output: {
+      file: 'dist/providers.umd.min.js',
+      format: 'umd',
+      name: 'typescriptExpressionLanguageProviders',
+      sourcemap: false,
+    },
+    plugins: [
+      resolve({
+        preferBuiltins: false,
+        browser: true,
+      }),
+      commonjs(),
+      typescript({
+        tsconfig: './tsconfig.json',
+        declaration: false,
+        declarationMap: false,
+        tslib: 'bundled',
+      }),
+      terser(),
+    ],
+  },
   // Type definitions
   {
     input: 'src/index.ts',
@@ -109,5 +214,18 @@ export default [
       format: 'es',
     },
     plugins: [dts()],
+  },
+  // Providers type definitions
+  {
+    input: 'src/providers/index.ts',
+    output: {
+      file: 'dist/providers.d.ts',
+      format: 'es',
+    },
+    // Re-declaring ExpressionFunction here would make it a *different* type to
+    // consumers: TypeScript compares classes with private members nominally, so
+    // `new ExpressionLanguage(undefined, [new StringProvider()])` would fail to
+    // compile. Point the core types at the main entry instead of inlining them.
+    plugins: [importCoreTypesFromMainEntry, dts()],
   },
 ];

--- a/src/expression-language.test.ts
+++ b/src/expression-language.test.ts
@@ -277,6 +277,27 @@ describe('ExpressionLanguage', () => {
     expect(expressionLanguage.evaluate('isset(val)', { val: undefined })).toBe(false);
   });
 
+  test('should evaluate now() as the current timestamp', () => {
+    const before = Date.now();
+    const result = expressionLanguage.evaluate('now()');
+    const after = Date.now();
+
+    expect(result).toBeGreaterThanOrEqual(before);
+    expect(result).toBeLessThanOrEqual(after);
+  });
+
+  test('should preserve regular expression escapes in string literals', () => {
+    expect(expressionLanguage.evaluate("'2026-07' matches '/^\\d{4}-\\d{2}$/'")).toBe(true);
+  });
+
+  test('should concatenate values as strings with ~', () => {
+    expect(expressionLanguage.evaluate('"foo" ~ "bar"')).toBe('foobar');
+    expect(expressionLanguage.evaluate('1 ~ 2')).toBe('12');
+    expect(expressionLanguage.evaluate('"v=" ~ value', { value: true })).toBe('v=true');
+    expect(expressionLanguage.evaluate('"v=" ~ value', { value: false })).toBe('v=false');
+    expect(expressionLanguage.evaluate('"v=" ~ value', { value: null })).toBe('v=null');
+  });
+
   test('should compile isset() correctly', () => {
     expect(expressionLanguage.compile('isset()', [])).toBe('false');
     expect(expressionLanguage.compile('isset(val)', ['val'])).toBe('(val != null)');

--- a/src/lexer.test.ts
+++ b/src/lexer.test.ts
@@ -57,6 +57,9 @@ const getTokenizeData = (): (string | Token[])[][] => {
     ],
     [[new Token(Token.STRING_TYPE, '#foo', 1)], "'#foo'"],
     [[new Token(Token.STRING_TYPE, '#foo', 1)], '"#foo"'],
+    [[new Token(Token.STRING_TYPE, "it's", 1)], "'it\\'s'"],
+    [[new Token(Token.STRING_TYPE, 'a"b', 1)], '"a\\"b"'],
+    [[new Token(Token.STRING_TYPE, 'c:\\tmp', 1)], "'c:\\\\tmp'"],
     [
       [
         new Token(Token.NAME_TYPE, 'foo', 1),

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -100,12 +100,9 @@ export class Lexer {
           throw new SyntaxError(`Unexpected "${expression[cursor]}"`, cursor, expression);
         }
 
-        const lastBracket = brackets.pop();
-        if (lastBracket) {
-          const [expected, cur] = lastBracket;
-          if (expression[cursor] !== { '(': ')', '[': ']', '{': '}' }[expected]) {
-            throw new SyntaxError(`Unclosed "${expected}"`, cur, expression);
-          }
+        const [expected, cur] = brackets.pop()!;
+        if (expression[cursor] !== { '(': ')', '[': ']', '{': '}' }[expected]) {
+          throw new SyntaxError(`Unclosed "${expected}"`, cur, expression);
         }
 
         tokens.push(new Token(Token.PUNCTUATION_TYPE, expression[cursor], cursor + 1));
@@ -116,7 +113,8 @@ export class Lexer {
       // Match strings (double-quoted or single-quoted)
       const stringMatch = Lexer.STRING_REGEX.exec(slicedExpression);
       if (stringMatch != null) {
-        tokens.push(new Token(Token.STRING_TYPE, stringMatch[1] ?? stringMatch[2], cursor + 1));
+        const rawValue = stringMatch[1] ?? stringMatch[2];
+        tokens.push(new Token(Token.STRING_TYPE, Lexer.unescapeString(rawValue), cursor + 1));
         cursor += stringMatch[0].length;
         continue;
       }
@@ -173,11 +171,8 @@ export class Lexer {
 
     // Check for unclosed brackets
     if (brackets.length > 0) {
-      const lastBracket = brackets.pop();
-      if (lastBracket) {
-        const [expect, cur] = lastBracket;
-        throw new SyntaxError(`Unclosed "${expect}"`, cur, expression);
-      }
+      const [expect, cur] = brackets.pop()!;
+      throw new SyntaxError(`Unclosed "${expect}"`, cur, expression);
     }
 
     return new TokenStream(tokens, expression);
@@ -220,5 +215,30 @@ export class Lexer {
       }
     }
     return null;
+  }
+
+  /**
+   * Unescapes quotes and literal backslashes while preserving JavaScript regex
+   * escapes such as `\d`.
+   * @private
+   * @param {string} raw - The raw string content between the quotes.
+   * @returns {string} The unescaped string value.
+   * @memberof Lexer
+   */
+  private static unescapeString(raw: string): string {
+    if (!raw.includes('\\')) {
+      return raw;
+    }
+    let result = '';
+    for (let i = 0; i < raw.length; i++) {
+      const next = raw[i + 1];
+      if (raw[i] === '\\' && (next === "'" || next === '"' || next === '\\')) {
+        result += next;
+        i++;
+      } else {
+        result += raw[i];
+      }
+    }
+    return result;
   }
 }

--- a/src/node/binary-node.test.ts
+++ b/src/node/binary-node.test.ts
@@ -12,10 +12,7 @@ const generateNode = (): ArrayNode => {
 };
 
 const getEvaluateData = (): (
-  | (boolean | BinaryNode)[]
-  | (number | BinaryNode)[]
-  | (string | BinaryNode)[]
-  | (BinaryNode | number[])[]
+  (boolean | BinaryNode)[] | (number | BinaryNode)[] | (string | BinaryNode)[] | (BinaryNode | number[])[]
 )[] => {
   const array = generateNode();
   return [

--- a/src/node/binary-node.ts
+++ b/src/node/binary-node.ts
@@ -178,7 +178,7 @@ export class BinaryNode extends Node {
    * Evaluates matches
    * @param regexp
    * @param str
-   * @returns true if matches
+   * @returns true if the expression matches.
    * @memberof BinaryNode
    */
   private evaluateMatches(regexp: string, str: string | null): boolean {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -282,6 +282,15 @@ describe('Parser', () => {
     }).toThrow(SyntaxError);
   });
 
+  test('should throw a clear error when names is not an array', () => {
+    const stream = lexer.tokenize('a + b');
+    expect(() => parser.parse(stream, 'foo' as unknown as string[])).toThrow(TypeError);
+    expect(() => parser.parse(stream, 'foo' as unknown as string[])).toThrow('The "names" argument must be an array.');
+    expect(() => parser.lint(lexer.tokenize('a + b'), null as unknown as string[])).toThrow(
+      'The "names" argument must be an array.'
+    );
+  });
+
   test('should create NullCoalescedNameNode for unknown variable followed by null coalescing operator', () => {
     const result = parser.parse(lexer.tokenize('unknownVar ?? "default"'), []);
     expect(result).toBeInstanceOf(NullCoalesceNode);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -170,7 +170,7 @@ export class Parser {
               return this.parsePostfixExpression(new FunctionNode(token.value, this.parseArguments()));
             } else {
               if (!(this.flags & Parser.IGNORE_UNKNOWN_VARIABLES) && token.value !== null) {
-                const names = (Array.isArray(this.names) ? this.names : [this.names]).reduce(
+                const names = this.names.reduce(
                   (out: { original: any; mapped: string | number }[], elem: string | number | Record<string, any>) => {
                     if (typeof elem === 'object' && elem !== null) {
                       out.push(...Object.entries(elem).map(([key, value]) => ({ original: value, mapped: key }))); // Store the mapping as {original, mapped}
@@ -199,10 +199,7 @@ export class Parser {
 
                 // is the name used in the compiled code different
                 // from the name used in the expression?
-                const name = names.find((x) => x.original === token.value);
-                if (name) {
-                  token.value = name.mapped;
-                }
+                token.value = validName.mapped;
               }
               return this.parsePostfixExpression(new NameNode(token.value));
             }
@@ -399,6 +396,9 @@ export class Parser {
    * @memberof Parse
    */
   private doParse(stream: TokenStream, names: (string | number | Record<string, any>)[], flags: number): Node {
+    if (!Array.isArray(names)) {
+      throw new TypeError('The "names" argument must be an array.');
+    }
     this.flags = flags;
     this.stream = stream;
     this.names = names;

--- a/src/providers/array-provider.ts
+++ b/src/providers/array-provider.ts
@@ -1,0 +1,76 @@
+import { array_intersect } from 'locutus/php/array/array_intersect';
+import { array_keys } from 'locutus/php/array/array_keys';
+import { array_merge } from 'locutus/php/array/array_merge';
+import { array_reverse } from 'locutus/php/array/array_reverse';
+import { array_slice } from 'locutus/php/array/array_slice';
+import { array_sum } from 'locutus/php/array/array_sum';
+import { array_unique } from 'locutus/php/array/array_unique';
+import { array_values } from 'locutus/php/array/array_values';
+import { count } from 'locutus/php/array/count';
+import { in_array } from 'locutus/php/array/in_array';
+import { implode } from 'locutus/php/strings/implode';
+import { ExpressionFunction } from '../expression-function';
+import type { ExpressionFunctionProvider } from '../expression-language';
+
+/** Locutus PHP array and collection functions. */
+export class ArrayProvider implements ExpressionFunctionProvider {
+  public getFunctions(): ExpressionFunction[] {
+    return [
+      new ExpressionFunction(
+        'count',
+        (...args) => `count(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(count, undefined, args)
+      ),
+      new ExpressionFunction(
+        'implode',
+        (...args) => `implode(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(implode, undefined, args)
+      ),
+      new ExpressionFunction(
+        'array_keys',
+        (...args) => `array_keys(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(array_keys, undefined, args)
+      ),
+      new ExpressionFunction(
+        'array_values',
+        (...args) => `array_values(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(array_values, undefined, args)
+      ),
+      new ExpressionFunction(
+        'array_merge',
+        (...args) => `array_merge(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(array_merge, undefined, args)
+      ),
+      new ExpressionFunction(
+        'array_reverse',
+        (...args) => `array_reverse(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(array_reverse, undefined, args)
+      ),
+      new ExpressionFunction(
+        'array_unique',
+        (...args) => `array_unique(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(array_unique, undefined, args)
+      ),
+      new ExpressionFunction(
+        'array_sum',
+        (...args) => `array_sum(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(array_sum, undefined, args)
+      ),
+      new ExpressionFunction(
+        'in_array',
+        (...args) => `in_array(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(in_array, undefined, args)
+      ),
+      new ExpressionFunction(
+        'array_intersect',
+        (...args) => `array_intersect(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(array_intersect, undefined, args)
+      ),
+      new ExpressionFunction(
+        'array_slice',
+        (...args) => `array_slice(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(array_slice, undefined, args)
+      ),
+    ];
+  }
+}

--- a/src/providers/date-provider.ts
+++ b/src/providers/date-provider.ts
@@ -1,0 +1,63 @@
+import { checkdate } from 'locutus/php/datetime/checkdate';
+import { date } from 'locutus/php/datetime/date';
+import { date_parse } from 'locutus/php/datetime/date_parse';
+import { gmdate } from 'locutus/php/datetime/gmdate';
+import { gmmktime } from 'locutus/php/datetime/gmmktime';
+import { mktime } from 'locutus/php/datetime/mktime';
+import { strtotime } from 'locutus/php/datetime/strtotime';
+import { time } from 'locutus/php/datetime/time';
+import { ExpressionFunction } from '../expression-function';
+import type { ExpressionFunctionProvider } from '../expression-language';
+
+/**
+ * Locutus PHP date functions.
+ *
+ * Timestamps use PHP seconds: `strtotime()` returns seconds and `date()`
+ * accepts seconds.
+ */
+export class DateProvider implements ExpressionFunctionProvider {
+  public getFunctions(): ExpressionFunction[] {
+    return [
+      new ExpressionFunction(
+        'checkdate',
+        (...args) => `checkdate(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(checkdate, undefined, args)
+      ),
+      new ExpressionFunction(
+        'date',
+        (...args) => `date(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(date, undefined, args)
+      ),
+      new ExpressionFunction(
+        'date_parse',
+        (...args) => `date_parse(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(date_parse, undefined, args)
+      ),
+      new ExpressionFunction(
+        'gmdate',
+        (...args) => `gmdate(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(gmdate, undefined, args)
+      ),
+      new ExpressionFunction(
+        'gmmktime',
+        (...args) => `gmmktime(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(gmmktime, undefined, args)
+      ),
+      new ExpressionFunction(
+        'mktime',
+        (...args) => `mktime(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(mktime, undefined, args)
+      ),
+      new ExpressionFunction(
+        'strtotime',
+        (...args) => `strtotime(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(strtotime, undefined, args)
+      ),
+      new ExpressionFunction(
+        'time',
+        (...args) => `time(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(time, undefined, args)
+      ),
+    ];
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Optional, opt-in function providers.
+ *
+ * These live behind the `/providers` entry point so the core bundle stays
+ * lean. They are backed by the project's existing Locutus dependency.
+ *
+ * ```ts
+ * import { ExpressionLanguage } from '@andreasnicolaou/typescript-expression-language';
+ * import { StringProvider, ArrayProvider } from '@andreasnicolaou/typescript-expression-language/providers';
+ *
+ * const el = new ExpressionLanguage(undefined, [new StringProvider(), new ArrayProvider()]);
+ * ```
+ */
+export { ArrayProvider } from './array-provider';
+export { DateProvider } from './date-provider';
+export { MathProvider } from './math-provider';
+export { StringProvider } from './string-provider';

--- a/src/providers/math-provider.ts
+++ b/src/providers/math-provider.ts
@@ -1,0 +1,50 @@
+import { abs } from 'locutus/php/math/abs';
+import { ceil } from 'locutus/php/math/ceil';
+import { floor } from 'locutus/php/math/floor';
+import { pow } from 'locutus/php/math/pow';
+import { round } from 'locutus/php/math/round';
+import { sqrt } from 'locutus/php/math/sqrt';
+import { ExpressionFunction } from '../expression-function';
+import type { ExpressionFunctionProvider } from '../expression-language';
+
+/**
+ * Bundles Locutus PHP math functions so they can be registered in one call.
+ * `min` and `max` are already registered by ExpressionLanguage by default,
+ * so they are intentionally omitted here.
+ */
+export class MathProvider implements ExpressionFunctionProvider {
+  public getFunctions(): ExpressionFunction[] {
+    return [
+      new ExpressionFunction(
+        'abs',
+        (...args) => `abs(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(abs, undefined, args)
+      ),
+      new ExpressionFunction(
+        'ceil',
+        (...args) => `ceil(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(ceil, undefined, args)
+      ),
+      new ExpressionFunction(
+        'floor',
+        (...args) => `floor(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(floor, undefined, args)
+      ),
+      new ExpressionFunction(
+        'round',
+        (...args) => `round(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(round, undefined, args)
+      ),
+      new ExpressionFunction(
+        'sqrt',
+        (...args) => `sqrt(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(sqrt, undefined, args)
+      ),
+      new ExpressionFunction(
+        'pow',
+        (...args) => `pow(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(pow, undefined, args)
+      ),
+    ];
+  }
+}

--- a/src/providers/providers.test.ts
+++ b/src/providers/providers.test.ts
@@ -1,0 +1,156 @@
+import { round } from 'locutus/php/math/round';
+import { ExpressionLanguage, type ExpressionFunctionProvider } from '../expression-language';
+import { ArrayProvider, DateProvider, MathProvider, StringProvider } from './index';
+
+type EvaluatorCase = readonly [name: string, args: unknown[], expected: unknown];
+
+const providers: ExpressionFunctionProvider[] = [
+  new MathProvider(),
+  new StringProvider(),
+  new ArrayProvider(),
+  new DateProvider(),
+];
+
+const invoke = (provider: ExpressionFunctionProvider, name: string, args: unknown[]): unknown => {
+  const expressionFunction = provider.getFunctions().find((fn) => fn.getName() === name);
+  if (!expressionFunction) {
+    throw new Error(`Provider does not expose ${name}().`);
+  }
+  return expressionFunction.getEvaluator()(Object.create(null), ...args);
+};
+
+describe('providers', () => {
+  test('expose the documented Locutus function sets', () => {
+    expect(providers.map((provider) => provider.getFunctions().map((fn) => fn.getName()))).toEqual([
+      ['abs', 'ceil', 'floor', 'round', 'sqrt', 'pow'],
+      [
+        'strtolower',
+        'strtoupper',
+        'strlen',
+        'trim',
+        'ltrim',
+        'rtrim',
+        'ucfirst',
+        'lcfirst',
+        'ucwords',
+        'strrev',
+        'explode',
+        'str_replace',
+        'substr',
+      ],
+      [
+        'count',
+        'implode',
+        'array_keys',
+        'array_values',
+        'array_merge',
+        'array_reverse',
+        'array_unique',
+        'array_sum',
+        'in_array',
+        'array_intersect',
+        'array_slice',
+      ],
+      ['checkdate', 'date', 'date_parse', 'gmdate', 'gmmktime', 'mktime', 'strtotime', 'time'],
+    ]);
+  });
+
+  test('register, evaluate, and compile through ExpressionLanguage', () => {
+    const el = new ExpressionLanguage(undefined, providers);
+    expect(el.evaluate('round(-1.5)')).toBe(-2);
+    expect(el.evaluate('strtoupper(implode("", array_reverse(["a", "b"])))')).toBe('BA');
+    expect(el.evaluate('array_unique([1, "1", 2])')).toEqual({ 0: 1, 2: 2 });
+    expect(el.evaluate('gmdate("Y", 0)')).toBe('1970');
+
+    const compiled = el.compile('round(value)', ['value']);
+    expect(compiled).toBe('round(value)');
+    expect(new Function('round', 'value', `return ${compiled};`)(round, -1.5)).toBe(-2);
+  });
+});
+
+describe('provider forwarding contracts', () => {
+  test('every registered compiler emits its function call', () => {
+    for (const provider of providers) {
+      for (const expressionFunction of provider.getFunctions()) {
+        const name = expressionFunction.getName();
+        expect(expressionFunction.getCompiler()('value')).toBe(`${name}(value)`);
+      }
+    }
+  });
+
+  test('every MathProvider evaluator delegates to Locutus', () => {
+    const cases: EvaluatorCase[] = [
+      ['abs', [-5], 5],
+      ['ceil', [3.2], 4],
+      ['floor', [3.8], 3],
+      ['round', [-1.5], -2],
+      ['sqrt', [9], 3],
+      ['pow', [2, 10], 1024],
+    ];
+
+    for (const [name, args, expected] of cases) {
+      expect(invoke(providers[0], name, args)).toEqual(expected);
+    }
+  });
+
+  test('every StringProvider evaluator delegates to Locutus', () => {
+    const cases: EvaluatorCase[] = [
+      ['strtolower', ['HELLO'], 'hello'],
+      ['strtoupper', ['hello'], 'HELLO'],
+      ['strlen', ['hello'], 5],
+      ['trim', ['  hi  '], 'hi'],
+      ['ltrim', ['  hi'], 'hi'],
+      ['rtrim', ['hi  '], 'hi'],
+      ['ucfirst', ['hello'], 'Hello'],
+      ['lcfirst', ['HELLO'], 'hELLO'],
+      ['ucwords', ['hello world'], 'Hello World'],
+      ['strrev', ['abc'], 'cba'],
+      ['explode', [',', 'a,b'], ['a', 'b']],
+      ['str_replace', ['o', '0', 'foo'], 'f00'],
+      ['substr', ['hello', 1, -1], 'ell'],
+    ];
+
+    for (const [name, args, expected] of cases) {
+      expect(invoke(providers[1], name, args)).toEqual(expected);
+    }
+  });
+
+  test('every ArrayProvider evaluator delegates to Locutus', () => {
+    const cases: EvaluatorCase[] = [
+      ['count', [[1, 2, 3]], 3],
+      ['implode', ['-', [1, 2, 3]], '1-2-3'],
+      ['array_keys', [{ a: 1, b: 2 }], ['a', 'b']],
+      ['array_values', [{ a: 1, b: 2 }], [1, 2]],
+      ['array_merge', [{ a: 1 }, { b: 2 }], { a: 1, b: 2 }],
+      ['array_reverse', [[1, 2, 3]], [3, 2, 1]],
+      ['array_unique', [[1, '1', 2]], { 0: 1, 2: 2 }],
+      ['array_sum', [[1, 2, 3]], 6],
+      ['in_array', [1, ['1']], true],
+      [
+        'array_intersect',
+        [
+          [1, 2, 3],
+          [2, 3],
+        ],
+        { 1: 2, 2: 3 },
+      ],
+      ['array_slice', [[1, 2, 3], 1], [2, 3]],
+    ];
+
+    for (const [name, args, expected] of cases) {
+      expect(invoke(providers[2], name, args)).toEqual(expected);
+    }
+  });
+
+  test('every DateProvider evaluator delegates to Locutus', () => {
+    const dateProvider = providers[3];
+    expect(invoke(dateProvider, 'checkdate', [2, 29, 2024])).toBe(true);
+    expect(invoke(dateProvider, 'date', ['Y', 0])).toBe('1970');
+    expect(invoke(dateProvider, 'date_parse', ['2026-07-21'])).toMatchObject({ year: 2026, month: 7, day: 21 });
+    expect(invoke(dateProvider, 'gmdate', ['Y', 0])).toBe('1970');
+    expect(invoke(dateProvider, 'gmmktime', [0, 0, 0, 1, 1, 1970])).toBe(0);
+    expect(typeof invoke(dateProvider, 'mktime', [0, 0, 0, 1, 1, 1970])).toBe('number');
+    expect(typeof invoke(dateProvider, 'strtotime', ['2026-07-21T00:00:00'])).toBe('number');
+    expect(typeof invoke(dateProvider, 'time', [])).toBe('number');
+  });
+});

--- a/src/providers/string-provider.ts
+++ b/src/providers/string-provider.ts
@@ -1,0 +1,88 @@
+import { explode } from 'locutus/php/strings/explode';
+import { lcfirst } from 'locutus/php/strings/lcfirst';
+import { ltrim } from 'locutus/php/strings/ltrim';
+import { rtrim } from 'locutus/php/strings/rtrim';
+import { str_replace } from 'locutus/php/strings/str_replace';
+import { strlen } from 'locutus/php/strings/strlen';
+import { strrev } from 'locutus/php/strings/strrev';
+import { strtolower } from 'locutus/php/strings/strtolower';
+import { strtoupper } from 'locutus/php/strings/strtoupper';
+import { substr } from 'locutus/php/strings/substr';
+import { trim } from 'locutus/php/strings/trim';
+import { ucfirst } from 'locutus/php/strings/ucfirst';
+import { ucwords } from 'locutus/php/strings/ucwords';
+import { ExpressionFunction } from '../expression-function';
+import type { ExpressionFunctionProvider } from '../expression-language';
+
+/** Locutus PHP string functions. */
+export class StringProvider implements ExpressionFunctionProvider {
+  public getFunctions(): ExpressionFunction[] {
+    return [
+      new ExpressionFunction(
+        'strtolower',
+        (...args) => `strtolower(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(strtolower, undefined, args)
+      ),
+      new ExpressionFunction(
+        'strtoupper',
+        (...args) => `strtoupper(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(strtoupper, undefined, args)
+      ),
+      new ExpressionFunction(
+        'strlen',
+        (...args) => `strlen(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(strlen, undefined, args)
+      ),
+      new ExpressionFunction(
+        'trim',
+        (...args) => `trim(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(trim, undefined, args)
+      ),
+      new ExpressionFunction(
+        'ltrim',
+        (...args) => `ltrim(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(ltrim, undefined, args)
+      ),
+      new ExpressionFunction(
+        'rtrim',
+        (...args) => `rtrim(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(rtrim, undefined, args)
+      ),
+      new ExpressionFunction(
+        'ucfirst',
+        (...args) => `ucfirst(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(ucfirst, undefined, args)
+      ),
+      new ExpressionFunction(
+        'lcfirst',
+        (...args) => `lcfirst(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(lcfirst, undefined, args)
+      ),
+      new ExpressionFunction(
+        'ucwords',
+        (...args) => `ucwords(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(ucwords, undefined, args)
+      ),
+      new ExpressionFunction(
+        'strrev',
+        (...args) => `strrev(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(strrev, undefined, args)
+      ),
+      new ExpressionFunction(
+        'explode',
+        (...args) => `explode(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(explode, undefined, args)
+      ),
+      new ExpressionFunction(
+        'str_replace',
+        (...args) => `str_replace(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(str_replace, undefined, args)
+      ),
+      new ExpressionFunction(
+        'substr',
+        (...args) => `substr(${args.join(', ')})`,
+        (_context, ...args) => Reflect.apply(substr, undefined, args)
+      ),
+    ];
+  }
+}


### PR DESCRIPTION
- Updated package version from 2.0.0 to 3.0.0 in package.json.
- Added ArrayProvider, DateProvider, and MathProvider to support additional PHP functions.
- Enhanced ExpressionLanguage with new evaluation capabilities including now(), string concatenation, and regex handling.
- Improved lexer and parser to handle new string escape scenarios and added error handling for non-array names.
- Introduced tests for new providers and their functions to ensure correct behavior.
- Updated Rollup configuration to include new provider entry points and type definitions.